### PR TITLE
TLS loading fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,7 @@ dependencies = [
  "tokio",
  "uhlc 0.5.2",
  "webpki",
+ "webpki-roots",
  "zenoh",
  "zenoh-buffers",
  "zenoh-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ serde_json = "1.0.94"
 tokio = { version = "1.26.0", features = ["full"] }
 uhlc = "0.5.2"
 webpki = "0.22.0"
+webpki-roots = "0.25"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master", features = ["unstable"] }
 zenoh_backend_traits = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }
 zenoh-buffers = { git = "https://github.com/eclipse-zenoh/zenoh", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -90,11 +90,8 @@ If successful, then the console can be accessed on http://localhost:9090.
             //    // Certificate authority to authenticate the server.
             //    root_ca_certificate_file: "/home/user/certificates/minio/ca.pem",
             //
-            //    // Alternatively you can inline your certificate:
-            //    // - encoded with base 64:
+            //    // Alternatively you can inline your certificate encoded with base 64:
             //    root_ca_certificate_base64: "<YOUR_CERTIFICATE_ENCODED_WITH_BASE64>"
-            //    // - raw:
-            //    root_ca_certificate_raw: "<YOUR_RAW_CERTIFICATE>"
             //  }
             //},
           },
@@ -256,7 +253,7 @@ tls: {
 ```
 
 Here, the `root_ca_certificate_file` corresponds to the generated _minica.pem_ file.
-You can also embed directly the root_ca_certificate by inlining it under the fileds `root_ca_certificate_base64` or `root_ca_certificate_raw` depending on the encoding.
+You can also embed directly the root_ca_certificate by inlining it under the filed `root_ca_certificate_base64`, encoded with base64.
 
 The _cert.pem_ and _key.pem_ files correspond to the public certificate and private key respectively. We need to rename them as _public.crt_ and _private.key_ respectively and store them under the MinIO configuration directory (as specified in the [MinIO documentation](https://min.io/docs/minio/linux/operations/network-encryption.html#enabling-tls)). In case you are using running a docker container as previously shown, then we will need to mount the folder containing the certificates as a volume; supposing we stored our certificates under `${HOME}/minio/certs`, we need to start our container as follows:
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,18 @@ If successful, then the console can be accessed on http://localhost:9090.
 
             // Optional TLS specific parameters to enable HTTPS with MinIO. Configuration shared by
             // all the associated storages.
-            tls: {
-              // Certificate authority to authenticate the server.
-              root_ca_certificate: "/home/user/certificates/minio/ca.pem",
-            },
+            // tls: {
+            //  private: {
+            //    // Certificate authority to authenticate the server.
+            //    root_ca_certificate_file: "/home/user/certificates/minio/ca.pem",
+            //
+            //    // Alternatively you can inline your certificate:
+            //    // - encoded with base 64:
+            //    root_ca_certificate_base64: "<YOUR_CERTIFICATE_ENCODED_WITH_BASE64>"
+            //    // - raw:
+            //    root_ca_certificate_raw: "<YOUR_RAW_CERTIFICATE>"
+            //  }
+            //},
           },
         },
         storages: {
@@ -236,16 +244,19 @@ a private key, a public certificate and a certificate authority certificate is g
     └── minica.pem
 ```
 
-On the config file, we need to specify the `root_ca_certificate` as this will allow the s3 plugin to validate the MinIO server keys.
+On the config file, we need to specify the `root_ca_certificate_file` as this will allow the s3 plugin to validate the MinIO server keys.
 Example:
 
 ```
 tls: {
-  root_ca_certificate: "/home/user/certificates/minio/minica.pem",
+  private: {
+    root_ca_certificate_file: "/home/user/certificates/minio/minica.pem",
+  },
 },
 ```
 
-Here, the `root_ca_certificate` corresponds to the generated _minica.pem_ file.
+Here, the `root_ca_certificate_file` corresponds to the generated _minica.pem_ file.
+You can also embed directly the root_ca_certificate by inlining it under the fileds `root_ca_certificate_base64` or `root_ca_certificate_raw` depending on the encoding.
 
 The _cert.pem_ and _key.pem_ files correspond to the public certificate and private key respectively. We need to rename them as _public.crt_ and _private.key_ respectively and store them under the MinIO configuration directory (as specified in the [MinIO documentation](https://min.io/docs/minio/linux/operations/network-encryption.html#enabling-tls)). In case you are using running a docker container as previously shown, then we will need to mount the folder containing the certificates as a volume; supposing we stored our certificates under `${HOME}/minio/certs`, we need to start our container as follows:
 
@@ -264,9 +275,11 @@ storage_manager: {
 
         // Configure TLS specific parameters
         tls: {
-          root_ca_certificate: "/home/user/certificates/minio_certs/minica.pem",
+          private: {
+            root_ca_certificate_file: "/home/user/certificates/minio_certs/minica.pem",
+          },
         },
-    }
+    },
   },
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ impl Volume for S3Backend {
     }
 
     async fn create_storage(&mut self, config: StorageConfig) -> ZResult<Box<dyn Storage>> {
-        log::debug!("Creating storage {:?}", config);
+        log::debug!("Creating storage...");
         let config: S3Config = S3Config::new(&config).await?;
 
         let client = S3Client::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use async_std::sync::Arc;
 use async_trait::async_trait;
 
 use client::S3Client;
-use config::{S3Config, TlsClientConfig};
+use config::{S3Config, TlsClientConfig, TLS_PROP};
 use futures::future::join_all;
 use futures::stream::FuturesUnordered;
 use utils::S3Key;
@@ -48,9 +48,6 @@ pub const NONE_KEY: &str = "@@none_key@@";
 
 // Metadata keys
 pub const TIMESTAMP_METADATA_KEY: &str = "timestamp_uhlc";
-
-// TLS properties
-const PROP_TLS: &str = "tls";
 
 // Amount of worker threads to be used by the tokio runtime of the [S3Storage] to handle incoming
 // operations.
@@ -108,10 +105,10 @@ fn get_optional_string_property(property: &str, config: &VolumeConfig) -> ZResul
 }
 
 fn load_tls_config(config: &VolumeConfig) -> ZResult<Option<TlsClientConfig>> {
-    match config.rest.get(PROP_TLS) {
+    match config.rest.get(TLS_PROP) {
         Some(serde_json::Value::Object(tls_config)) => Ok(Some(TlsClientConfig::new(tls_config)?)),
         None => Ok(None),
-        _ => Err(zerror!("Property {PROP_TLS} is malformed.").into()),
+        _ => Err(zerror!("Property {TLS_PROP} is malformed.").into()),
     }
 }
 

--- a/zenoh.json5
+++ b/zenoh.json5
@@ -4,41 +4,35 @@
     storage_manager: {
       volumes: {
         s3: {
+          // AWS region to which connect (see https://docs.aws.amazon.com/general/latest/gr/s3.html).
+          // This field is mandatory if you are going to communicate with an AWS S3 server and
+          // optional in case you are working with a MinIO S3 server.
+          region: "eu-west-1",
 
-            // AWS region to which connect (see https://docs.aws.amazon.com/general/latest/gr/s3.html). 
-            // This field is mandatory if you are going to communicate with an AWS S3 server and
-            // optional in case you are working with a MinIO S3 server.
-            region: "eu-west-1",
+          // Endpoint where the S3 server is located.
+          // This parameter allows you to specify a custom endpoint when working with a MinIO S3
+          // server.
+          // This field is mandatory if you are working with a MinIO server and optional in case
+          // you are working with an AWS S3 server as long as you specified the region, in which
+          // case the endpoint will be resolved automatically.
+          url: "https://s3.eu-west-1.amazonaws.com",
 
-            // Endpoint where the S3 server is located.
-            // This parameter allows you to specify a custom endpoint when working with a MinIO S3 
-            // server.
-            // This field is mandatory if you are working with a MinIO server and optional in case
-            // you are working with an AWS S3 server as long as you specified the region, in which
-            // case the endpoint will be resolved automatically.
-            url: "https://s3.eu-west-1.amazonaws.com",
-
-            // Optional TLS specific parameters to enable HTTPS with MINIO. 
-            // Configuration shared by all the associated storages. 
-            tls: {
-              private: {
-                
-                // Certificate authority to authenticate the server.
-                root_ca_certificate_file: "<YOUR_CERTIFICATE_PATH>",
-                // Alternatively you can inline your certificate:
-                // - encoded with base 64:
-                root_ca_certificate_base64: "<YOUR_CERTIFICATE_ENCODED_WITH_BASE64>",
-                // - raw certificate:
-                root_ca_certificate_raw: "<YOUR_RAW_CERTIFICATE>",
-              }
+          // Optional TLS specific parameters to enable HTTPS with MINIO.
+          // Configuration shared by all the associated storages.
+          tls: {
+            private: {
+              // Certificate authority to authenticate the server.
+              root_ca_certificate_file: "<YOUR_CERTIFICATE_PATH>",
+              // Alternatively you can inline your certificate encoded with base 64:
+              root_ca_certificate_base64: "<YOUR_CERTIFICATE_ENCODED_WITH_BASE64>",
             },
-        }
+          },
+        },
       },
       storages: {
         // Configuration of a "demo" storage using the S3 volume. Each storage is associated to a
         // single S3 bucket.
         s3_storage: {
-
           // The key expression this storage will subscribes to
           key_expr: "s3/example/*",
 
@@ -65,15 +59,15 @@
             on_closure: "destroy_bucket",
 
             private: {
-                // Credentials for interacting with the S3 bucket
-                access_key: "AKIAIOSFODNN7EXAMPLE",
-                secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+              // Credentials for interacting with the S3 bucket
+              access_key: "AKIAIOSFODNN7EXAMPLE",
+              secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
             },
-          }
+          },
         },
-      }
+      },
     },
     // Optionally, add the REST plugin
-    rest: { http_port: 8000 }
+    rest: { http_port: 8000 },
   },
 }

--- a/zenoh.json5
+++ b/zenoh.json5
@@ -18,11 +18,19 @@
             // case the endpoint will be resolved automatically.
             url: "https://s3.eu-west-1.amazonaws.com",
 
-            // Optional TLS specific parameters to enable HTTPS with MinIO. Configuration shared by
-            // all the associated storages. 
+            // Optional TLS specific parameters to enable HTTPS with MINIO. 
+            // Configuration shared by all the associated storages. 
             tls: {
-              // Certificate authority to authenticate the server.
-              root_ca_certificate: "./certificates/minio/ca.pem",
+              private: {
+                
+                // Certificate authority to authenticate the server.
+                root_ca_certificate_file: "<YOUR_CERTIFICATE_PATH>",
+                // Alternatively you can inline your certificate:
+                // - encoded with base 64:
+                root_ca_certificate_base64: "<YOUR_CERTIFICATE_ENCODED_WITH_BASE64>",
+                // - raw certificate:
+                root_ca_certificate_raw: "<YOUR_RAW_CERTIFICATE>",
+              }
             },
         }
       },


### PR DESCRIPTION
* Loading WebPKI certificates by default
* Fix crash when specifying an empty tls certificate
* TLS sensitive data now is loaded as private (i.e. the code expects the user to have specified the certificates wrapped around a 'private' key).
* Letting the user to inline the TLS certificate as base64.
* The field `root_ca_certificate` is now named `root_ca_certificate_file` to distinguish it from the new `root_ca_certificate_base64` file.
* Updated the README and the example configuration.

TESTED: Manually tested with MinIO and AWS.