### PR TITLE
feat: adding dynamic_plugin feature to enable the declare_plugin macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 stats = ["zenoh/stats"]
+dynamic_plugin = []
+default = ["dynamic_plugin"]
 
 [dependencies]
 async-rustls = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ pub const TIMESTAMP_METADATA_KEY: &str = "timestamp_uhlc";
 const STORAGE_WORKER_THREADS: usize = 2;
 
 pub struct S3Backend {}
+
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(S3Backend);
 
 impl Plugin for S3Backend {


### PR DESCRIPTION
Adding a `dynamic_plugin`  feature to feature-gate the `zenoh_plugin_trait::declare_plugin!` by default this feature is enabled.

Disabling it should allow static linking.