### PR TITLE
fix(issue #71): wildcard queries on AWS S3 failing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,8 @@ impl Storage for S3Storage {
                         let timestamp = metadata.get(TIMESTAMP_METADATA_KEY).ok_or_else(|| {
                             zerror!("Unable to retrieve timestamp for key '{}'.", object_key)
                         })?;
-                        let key_expr = OwnedKeyExpr::from_str(&object_key).map_err(|err| {
+                        let key_expr = OwnedKeyExpr::from_str(object_key.trim_start_matches('/'))
+                            .map_err(|err| {
                             zerror!(
                                 "Unable to generate key expression for key '{}': {}",
                                 &object_key,


### PR DESCRIPTION
On AWS S3 implementation, the path to an object may start with a `/`. This caused that we couldn't reconstruct the key expression associated to the object during wildcard operations.

Fixes #71 