### PR TITLE
issue(outdated dependencies): bumping AWS crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,10 @@ default = ["dynamic_plugin"]
 async-rustls = "0.4.0"
 async-std = { version = "=1.12.0", default-features = false, features = ["unstable", "tokio1"] }
 async-trait = "0.1.66"
-aws-config = "0.51.0"
-aws-sdk-s3 = "0.21.0"
-aws-smithy-client = "0.51.0"
+aws-config = "1.3.0"
+aws-sdk-s3 = { version = "1.25.0", features = ["behavior-version-latest"] }
+aws-smithy-client = "0.60.3"
+aws-smithy-runtime = "1.4.0"
 base64 = "0.21.0"
 futures = "0.3.26"
 git-version = "0.3.5"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.75.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,15 +15,20 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use aws_sdk_s3::model::{
+use aws_config::Region;
+use aws_sdk_s3::config::Credentials;
+use aws_sdk_s3::operation::create_bucket::CreateBucketOutput;
+use aws_sdk_s3::operation::delete_object::DeleteObjectOutput;
+use aws_sdk_s3::operation::delete_objects::DeleteObjectsOutput;
+use aws_sdk_s3::operation::get_object::GetObjectOutput;
+use aws_sdk_s3::operation::head_object::HeadObjectOutput;
+use aws_sdk_s3::operation::put_object::PutObjectOutput;
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::{
     BucketLocationConstraint, CreateBucketConfiguration, Delete, Object, ObjectIdentifier,
 };
-use aws_sdk_s3::output::{
-    CreateBucketOutput, DeleteObjectOutput, DeleteObjectsOutput, GetObjectOutput, HeadObjectOutput,
-};
-use aws_sdk_s3::{output::PutObjectOutput, types::ByteStream, Client};
-use aws_sdk_s3::{Credentials, Endpoint, Region};
-use aws_smithy_client::hyper_ext;
+use aws_sdk_s3::Client;
+use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 use zenoh::value::Value;
 use zenoh::Result as ZResult;
 use zenoh_buffers::buffer::SplitBuffer;
@@ -51,6 +56,7 @@ impl S3Client {
     ///     setting a MinIO instance. If None then the default AWS endpoint resolver will attempt
     ///     to retrieve the endpoint based on the specified region.
     /// * `tls_config`: optional TlsClientConfig to enable TLS security.
+    #[tokio::main]
     pub async fn new(
         credentials: Credentials,
         bucket: String,
@@ -64,35 +70,25 @@ impl S3Client {
         config_loader = match region {
             Some(ref region) => config_loader.region(Region::new(region.to_owned())),
             None => {
-                // The region MUST be specified to perform a request to an S3 server when using the
-                // aws_sdk_s3 crate. However when working with the MinIO S3 implementation (where
-                // the region is not considered) then in the config file the region is optional and
-                // we instead specify an empty region here below.
-                tracing::debug!("Region not specified. Setting empty region...");
-                config_loader.region(Region::new(""))
+                // A region MUST be specified when using the aws_sdk_s3 crate independently of the fact
+                // that it may not be used in the future (for instance when using MinIO).
+                tracing::debug!("Region not specified. Setting 'us-east-1' region by default...");
+                config_loader.region(Region::new("us-east-1"))
             }
         };
 
-        config_loader = match endpoint {
-            Some(endpoint) => config_loader.endpoint_resolver(Endpoint::immutable(
-                endpoint.parse().expect("Invalid endpoint: "),
-            )),
-            None => {
-                tracing::debug!("Endpoint not specified.");
-                config_loader
-            }
-        };
+        if let Some(endpoint) = endpoint {
+            config_loader = config_loader.endpoint_url(endpoint)
+        }
 
-        let config = &config_loader.load().await;
+        let sdk_config = &config_loader.load().await;
+        let mut config = aws_sdk_s3::config::Builder::from(sdk_config).force_path_style(true);
 
-        let client = if let Some(tls_config) = tls_config {
-            Client::from_conf_conn(
-                config.into(),
-                hyper_ext::Adapter::builder().build(tls_config.https_connector),
-            )
-        } else {
-            Client::new(config)
-        };
+        if let Some(tls_config) = tls_config {
+            config = config.http_client(HyperClientBuilder::new().build(tls_config.https_connector))
+        }
+
+        let client = Client::from_conf(config.build());
 
         S3Client {
             client,
@@ -172,13 +168,13 @@ impl S3Client {
         for object in objects {
             let identifier = ObjectIdentifier::builder()
                 .set_key(object.key().map(|x| x.to_string()))
-                .build();
+                .build()?;
             object_identifiers.push(identifier);
         }
 
         let delete = Delete::builder()
             .set_objects(Some(object_identifiers))
-            .build();
+            .build()?;
 
         Ok(self
             .client
@@ -214,17 +210,25 @@ impl S3Client {
             .await;
 
         match result {
-            Ok(output) => Ok(Some(output)),
-            Err(aws_sdk_s3::types::SdkError::ServiceError { err, raw }) => {
-                if err.is_bucket_already_owned_by_you() && reuse_bucket {
-                    return Ok(None);
-                };
-                Err(zerror!("Couldn't associate bucket '{self}': {raw:?}").into())
+                Ok(output) => Ok(Some(output)),
+                Err(err) => {
+                    match err.into_service_error() {
+                        aws_sdk_s3::operation::create_bucket::CreateBucketError::BucketAlreadyOwnedByYou(_) => {
+                            if reuse_bucket {
+                                Ok(None)
+                            } else {
+                                Err(zerror!(
+                                    "Attempted to create bucket but '{self}' but it already exists and is
+                                    already owned by you while 'reuse_bucket' is set to false in the configuration."
+                                ).into())
+                            }
+                        },
+                        err => Err(zerror!(
+                            "Couldn't create or associate bucket '{self}': {err:?}."
+                        ).into()),
+                    }
+                }
             }
-            Err(err) => {
-                Err(zerror!("Couldn't create or associate bucket '{self}': {err:?}.").into())
-            }
-        }
     }
 
     /// Deletes the bucket associated to this storage.
@@ -250,7 +254,7 @@ impl S3Client {
             .bucket(self.bucket.to_owned())
             .send()
             .await?;
-        Ok(response.contents().unwrap_or_default().to_vec())
+        Ok(response.contents().to_vec())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,8 @@
 //
 
 use async_rustls::rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
-use aws_sdk_s3::Credentials;
+
+use aws_sdk_s3::config::Credentials;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
 use rustls_pki_types::CertificateDer;
@@ -327,7 +328,7 @@ impl TlsClientConfig {
     }
 
     fn load_root_ca_certificate_base64_trust_anchors(
-        b64_certificate: &String,
+        b64_certificate: &str,
         root_cert_store: &mut RootCertStore,
     ) -> ZResult<()> {
         if b64_certificate.is_empty() {
@@ -336,7 +337,7 @@ impl TlsClientConfig {
             );
             return Ok(());
         };
-        let certificate_pem = Self::base64_decode(b64_certificate.as_str())?;
+        let certificate_pem = Self::base64_decode(b64_certificate)?;
         let mut pem = BufReader::new(certificate_pem.as_slice());
         let certs: Vec<CertificateDer> =
             rustls_pemfile::certs(&mut pem).collect::<Result<_, _>>()?;


### PR DESCRIPTION
Upgrading AWS crates used for the S3 backend.

Requires a minimal rust toolchain of 1.75.0 (required by aws crates).

Closes #55 