### PR TITLE
Sync dev/1.0.0 with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --all-targets -- --deny warnings
+      
+      - name: Clippy no-default-features
+        run: cargo clippy --no-default-features --all-targets -- --deny warnings
 
       - name: Build
         run: cargo build --verbose --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "serde",
  "tracing",
@@ -3461,12 +3461,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "flume",
  "json5",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-global-executor",
  "lazy_static",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "aes",
  "hmac",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "zenoh-config",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "flume",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "socket2 0.5.6",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "futures",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "const_format",
  "libloading",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "const_format",
  "rand",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "anyhow",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "futures",
  "lazy_static",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "event-listener 4.0.0",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "futures",
  "tokio",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-trait",
  "flume",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#75aa2739c36533f57b0eef3580256014e445f241"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "serde",
  "tracing",
@@ -3461,12 +3461,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "flume",
  "json5",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-global-executor",
  "lazy_static",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "aes",
  "hmac",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "zenoh-config",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "flume",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "base64",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "base64",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "socket2 0.5.6",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "futures",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "const_format",
  "libloading",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "const_format",
  "rand",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "anyhow",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "futures",
  "lazy_static",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "event-listener 4.0.0",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "futures",
  "tokio",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-trait",
  "flume",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#25f06bd9e71b4dbed5ba8d75eaa1708693e7b9ec"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "serde",
  "tracing",
@@ -3461,12 +3461,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "flume",
  "json5",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-global-executor",
  "lazy_static",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "aes",
  "hmac",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "zenoh-config",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "flume",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "base64",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "base64",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "socket2 0.5.6",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "futures",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "const_format",
  "libloading",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "const_format",
  "rand",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "anyhow",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "futures",
  "lazy_static",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "event-listener 4.0.0",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "futures",
  "tokio",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-trait",
  "flume",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0227b9f93e535d49bc7ce914c066243424ce85ed90864cebd0874b184e9b6947"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "serde",
  "tracing",
@@ -3461,12 +3461,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "flume",
  "json5",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-global-executor",
  "lazy_static",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "aes",
  "hmac",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "zenoh-config",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "flume",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "base64",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "base64",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "socket2 0.5.6",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "futures",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "const_format",
  "libloading",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "const_format",
  "rand",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "anyhow",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "futures",
  "lazy_static",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "event-listener 4.0.0",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "futures",
  "tokio",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-trait",
  "flume",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#d574654c618bf62f7baf9754f7c258d1b46f6465"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#c279982c131c556ebd474f4ffa9fd6c096d13830"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "serde",
  "tracing",
@@ -3461,12 +3461,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "flume",
  "json5",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-global-executor",
  "lazy_static",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "aes",
  "hmac",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "zenoh-config",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "flume",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "base64",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "base64",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "socket2 0.5.6",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "futures",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "const_format",
  "libloading",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "const_format",
  "rand",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "anyhow",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "futures",
  "lazy_static",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "event-listener 4.0.0",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "futures",
  "tokio",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-trait",
  "flume",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#3118d31b8c83343ac4dc990ae1bbdc59aa62f103"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#009f66612fe01953d8f75e9d92f1e8c79ffd2a74"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+checksum = "0227b9f93e535d49bc7ce914c066243424ce85ed90864cebd0874b184e9b6947"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,34 +12,37 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-name = "zenoh-backend-s3"
-version = "0.11.0-dev"
-repository = "https://github.com/eclipse-zenoh/zenoh-backend-s3"
-homepage = "http://zenoh.io"
 authors = [
-    "kydos <angelo@icorsaro.net>",
-    "Julien Enoch <julien@enoch.fr>",
-    "Olivier Hécart <olivier.hecart@zettascale.tech>",
-    "Luca Cominardi <luca.cominardi@zettascale.tech>",
-    "Darius Maitia <darius@zettascale.tech>",
+  "Darius Maitia <darius@zettascale.tech>",
+  "Julien Enoch <julien@enoch.fr>",
+  "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Olivier Hécart <olivier.hecart@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = "2021"
-license = "EPL-2.0 OR Apache-2.0"
-categories = ["network-programming", "database"]
+categories = ["database", "network-programming"]
 description = "Backend for Zenoh using AWS S3 API"
+edition = "2021"
+homepage = "http://zenoh.io"
+license = "EPL-2.0 OR Apache-2.0"
+name = "zenoh-backend-s3"
+repository = "https://github.com/eclipse-zenoh/zenoh-backend-s3"
+version = "0.11.0-dev"
 
 [lib]
-name = "zenoh_backend_s3"
 crate-type = ["cdylib", "rlib"]
+name = "zenoh_backend_s3"
 
 [features]
-stats = ["zenoh/stats"]
-dynamic_plugin = []
 default = ["dynamic_plugin"]
+dynamic_plugin = []
+stats = ["zenoh/stats"]
 
 [dependencies]
 async-rustls = "0.4.0"
-async-std = { version = "=1.12.0", default-features = false, features = ["unstable", "tokio1"] }
+async-std = { version = "=1.12.0", default-features = false, features = [
+  "tokio1",
+  "unstable",
+] }
 async-trait = "0.1.66"
 aws-config = "0.51.0"
 aws-sdk-s3 = "0.21.0"
@@ -55,29 +58,30 @@ rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.1.0"
 serde = "1.0.154"
 serde_json = "1.0.94"
-tracing = "0.1"
 tokio = { version = "1.26.0", features = ["full"] }
+tracing = "0.1"
 uhlc = "0.5.2"
 webpki = "0.22.0"
 webpki-roots = "0.25"
-zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = ["unstable"] }
-zenoh_backend_traits = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = [
+  "unstable",
+] }
 zenoh-buffers = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-codec = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-collections = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-core = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
-zenoh-protocol = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
-zenoh-util = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-keyexpr = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-plugin-trait = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
-
+zenoh-protocol = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh-util = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
+zenoh_backend_traits = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 [build-dependencies]
 rustc_version = "0.4.0"
 
 [package.metadata.deb]
-name = "zenoh-backend-s3"
-maintainer = "zenoh-dev@eclipse.org"
 copyright = "2022 ZettaScale Technology"
-section = "net"
-license-file = ["LICENSE", "0"]
 depends = "zenoh-plugin-storage-manager (=0.11.0-dev-1)"
+license-file = ["0", "LICENSE"]
+maintainer = "zenoh-dev@eclipse.org"
+name = "zenoh-backend-s3"
+section = "net"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ rustc_version = "0.4.0"
 [package.metadata.deb]
 copyright = "2022 ZettaScale Technology"
 depends = "zenoh-plugin-storage-manager (=0.11.0-dev-1)"
-license-file = ["0", "LICENSE"]
+license-file = ["LICENSE", "0"]
 maintainer = "zenoh-dev@eclipse.org"
 name = "zenoh-backend-s3"
 section = "net"

--- a/src/client.rs
+++ b/src/client.rs
@@ -196,7 +196,6 @@ impl S3Client {
     /// - Ok(Some(None)) in case the `reuse_bucket` parameter is true and the bucket already exists
     ///     and is owned by you
     /// - Error in any other case
-    #[tokio::main]
     pub async fn create_bucket(&self, reuse_bucket: bool) -> ZResult<Option<CreateBucketOutput>> {
         let constraint = self
             .region


### PR DESCRIPTION
Sync `ZettaScaleLabs:dev/1.0.0` ->  `eclipse-zenoh:dev/1.0.0` 

`ZettaScaleLabs:dev/1.0.0`  currently contains latest changes of `eclipse-zenoh:main` 