### PR TITLE
fix: remove tokio main

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -56,7 +56,6 @@ impl S3Client {
     ///     setting a MinIO instance. If None then the default AWS endpoint resolver will attempt
     ///     to retrieve the endpoint based on the specified region.
     /// * `tls_config`: optional TlsClientConfig to enable TLS security.
-    #[tokio::main]
     pub async fn new(
         credentials: Credentials,
         bucket: String,


### PR DESCRIPTION
I've found two wild `#[tokio::main]` in the code that lead to a nonworking statically linked version of this crate.
This is because `#[tokio::main]` expands to something containing a `block_on` that cause this crash: 

```
thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.38.0/src/runtime/scheduler/multi_thread/mod.rs:86:9:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

As a reminder, **NEVER** use `block_on` or anything that expands to a `block_on` in plugins.
