### PR TITLE
Fixed Cargo.lock syncronization with zenoh: aws-sigv4 locked to 1.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ checksum = "755df81cd785192ee212110f3df2b478704ddd19e7ac91263d23286c26384c4d"
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.7"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461e5e02f9864cba17cff30f007c2e37ade94d01e87cdb5204e44a84e6d38c17"
+checksum = "7c45d3dddac16c5c59d553ece225a88870cf81b7b813c9cc17b78cf4685eac7a"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.13"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b8a53819e42f10d0821f56da995e1470b199686a1809168db6ca485665f042"
+checksum = "40076bd09fadbc12d5e026ae080d0930defa606856186e31d83ccc6a255eeaf3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -627,9 +627,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytes-utils"
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1116,15 +1116,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1133,15 +1133,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1150,21 +1150,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1643,7 +1643,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -3741,7 +3741,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 [[package]]
 name = "zenoh"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3795,8 +3795,10 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "aws-sigv4",
  "aws-smithy-client",
  "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
  "base64 0.21.7",
  "futures",
  "git-version",
@@ -3822,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3830,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "tracing",
  "uhlc 0.8.0",
@@ -3841,7 +3843,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "ahash",
 ]
@@ -3849,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -3873,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3884,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "aes",
  "hmac",
@@ -3897,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "getrandom",
  "hashbrown 0.14.5",
@@ -3912,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3929,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "flume",
@@ -3953,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3980,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "socket2",
@@ -3997,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4026,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "socket2",
@@ -4045,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "nix",
@@ -4063,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -4083,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4094,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "git-version",
  "libloading",
@@ -4110,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "const_format",
  "rand",
@@ -4124,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "anyhow",
 ]
@@ -4132,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "zenoh-runtime"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "lazy_static",
  "ron",
@@ -4146,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -4160,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "zenoh-task"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "futures",
  "tokio",
@@ -4173,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -4206,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "const_format",
@@ -4231,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "zenoh_backend_traits"
 version = "1.3.4"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#babc2b1b7341f380f7e5453ea2e69135b1b4f6c3"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#53cb350ac30a46ce2715cc4e007828138038ef26"
 dependencies = [
  "async-trait",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ aws-config = "=1.0.0" # Due to MSRV 1.75.0 for aws-config
 aws-sdk-s3 = { version = "=1.29.0", features = [
   "behavior-version-latest",
 ] } # Due to MSRV 1.75.0 for aws-sdk-s3 >1.29
+aws-sigv4 = { version = "=1.2.9" } # Due to build issues with lazy_cell on rust 1.75 for 1.3.1
+aws-smithy-runtime-api = { version = "=1.7.3" } # to keep compatibility with aws-sigv4 1.2.9
 aws-smithy-client = "0.60.3"
 aws-smithy-runtime = "1.4.0"
 base64 = "0.21.0"


### PR DESCRIPTION
When aws-sigv4 bumps to 1.3.1 it causes incompatibility with rust 1.7.5. 
The solution is to lock aws-sigv4 to last rust 1.7.5 compatible version (1.2.9). Unfortunately the author of aws-sigv4 doesn't keep rust version compatibility records 