### PR TITLE
fix: Return None on NoSuchKey instead of service error

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -98,14 +98,24 @@ impl S3Client {
     }
 
     /// Retrieves the object associated to the [key] specified.
-    pub async fn get_object(&self, key: &str) -> ZResult<GetObjectOutput> {
-        Ok(self
+    ///
+    /// Returns `Ok(None)` if no object exists at [key].
+    pub async fn get_object(&self, key: &str) -> ZResult<Option<GetObjectOutput>> {
+        let result = self
             .client
             .get_object()
             .bucket(&self.bucket)
             .key(key.to_string())
             .send()
-            .await?)
+            .await;
+
+        match result {
+            Ok(output) => Ok(Some(output)),
+            Err(err) => match err.into_service_error() {
+                aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(_) => Ok(None),
+                err => Err(zerror!("Get operation failed for key '{key}': {err:?}").into()),
+            },
+        }
     }
 
     /// Retrieves the head object (the header of the object without its actual payload) associated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,15 +413,10 @@ impl S3Storage {
         let client = self.client.clone();
         let res = await_task!(client.get_object(key.as_str()).await, key);
 
-        let output_result = match res {
-            Ok(result) => Ok(result),
-            Err(e) => {
-                if e.to_string().contains("NoSuchKey") {
-                    return Ok(None);
-                }
-                Err(zerror!("Get operation failed for key '{key}': {e}"))
-            }
-        }?;
+        let output_result = match res? {
+            Some(result) => result,
+            None => return Ok(None),
+        };
 
         let metadata = output_result
             .metadata


### PR DESCRIPTION
We ended up in a looped error-retry storm because a key in zenohd's memory was missing in S3.  Instead of returning "NoSuchKey" (the string match "e.to_string().contains("NoSuchKey")" is actually broken against aws-sdk-s3 - the string doesn't contain that), we got back a "service error" which was infinitely retried.  After this PR, zenoh should be handling this case correctly.
