### PR TITLE
Make credentials optional to use the default AWS credential provider chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -4096,21 +4096,6 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uhlc"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
-dependencies = [
- "hex",
- "humantime",
- "lazy_static",
- "log",
- "serde",
- "spin 0.9.8",
- "uuid",
-]
-
-[[package]]
-name = "uhlc"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62a645e3e4e6c85b7abe49b086aa3204119431f42b6123b0070419fb6e9d24e"
@@ -4919,7 +4904,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uhlc 0.8.2",
+ "uhlc",
  "vec_map",
  "zenoh-buffers",
  "zenoh-codec",
@@ -4957,10 +4942,9 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
- "base64 0.21.7",
+ "base64 0.22.1",
  "futures",
  "git-version",
- "http 0.2.12",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "lazy_static",
@@ -4969,9 +4953,10 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "time",
  "tokio",
  "tracing",
- "uhlc 0.5.2",
+ "uhlc",
  "webpki",
  "webpki-roots 0.25.4",
  "zenoh",
@@ -4994,7 +4979,7 @@ version = "1.9.0"
 source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#1341765f895eefa643ec01b689eca1b12ddb2d9a"
 dependencies = [
  "tracing",
- "uhlc 0.8.2",
+ "uhlc",
  "zenoh-buffers",
  "zenoh-protocol",
 ]
@@ -5022,7 +5007,7 @@ dependencies = [
  "serde_yaml",
  "toml",
  "tracing",
- "uhlc 0.8.2",
+ "uhlc",
  "validated_struct",
  "zenoh-core",
  "zenoh-keyexpr",
@@ -5299,7 +5284,7 @@ dependencies = [
  "const_format",
  "rand 0.8.5",
  "serde",
- "uhlc 0.8.2",
+ "uhlc",
  "zenoh-buffers",
  "zenoh-keyexpr",
  "zenoh-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,25 +47,29 @@ aws-sdk-s3 = { version = "1.29.0", features = [
 aws-sigv4 = { version = "1.2.9" }
 aws-smithy-runtime-api = { version = "1.7.3" }
 aws-smithy-client = "0.60.3"
-aws-smithy-eventstream = "0.60.13"
-aws-smithy-types = "1.3.4"
+# Temporary pin aws-smithy-eventstream to 0.60.20 du to
+# https://github.com/smithy-lang/smithy-rs/issues/4695
+aws-smithy-eventstream = "=0.60.20"
+aws-smithy-types = "1.5.0"
+# Temporary pin time to <0.3.48, since version 0.3.48 is incompatible with aws-smithy-types 1.5.0
+# See https://github.com/smithy-lang/smithy-rs/issues/4698
+time = "=0.3.47"  #
 aws-smithy-async = "1.2.6"
 aws-smithy-xml = "0.60.12"
 aws-smithy-runtime = "1.4.0"
-base64 = "0.21.0"
+base64 = "0.22.1"
 futures = "0.3.26"
 git-version = "0.3.5"
-http = "0.2.9"
 hyper = "0.14.24"
 hyper-rustls = "0.24.0"
 lazy_static = "1.4.0"
-rustls-pemfile = "2.0.0"
+rustls-pemfile = "2.2.0"
 rustls-pki-types = "1.1.0"
 serde = "1.0.154"
 serde_json = "1.0.117"
 tokio = { version = "1.26.0", features = ["full"] }
 tracing = "0.1"
-uhlc = "0.5.2"
+uhlc = "0.8.0"
 webpki = "0.22.0"
 webpki-roots = "0.25"
 zenoh = { version = "1.9.0", features = [

--- a/EXAMPLE_CONFIG.json5
+++ b/EXAMPLE_CONFIG.json5
@@ -58,8 +58,11 @@
             // strategy on storage closure, either `destroy_bucket` or `do_nothing`
             on_closure: "destroy_bucket",
 
+            // Optional credentials for interacting with the S3 bucket.
+            //
+            // When this block is omitted, the AWS default credential provider chain is used, as described here:
+            // https://docs.rs/aws-config/latest/aws_config/default_provider/credentials/struct.DefaultCredentialsChain.html
             private: {
-              // Credentials for interacting with the S3 bucket
               access_key: "<YOUR ACCESS KEY>",
               secret_key: "<YOUR SECRET KEY>",
             },

--- a/README.md
+++ b/README.md
@@ -125,8 +125,11 @@ If successful, then the console can be accessed on [http://localhost:9090](http:
               // strategy on storage closure, either `destroy_bucket` or `do_nothing`
               on_closure: "destroy_bucket",
 
+              // Optional credentials for interacting with the S3 bucket.
+              //
+              // When this block is omitted, the AWS default credential provider chain is used, as described here:
+              // https://docs.rs/aws-config/latest/aws_config/default_provider/credentials/struct.DefaultCredentialsChain.html
               private: {
-                // Credentials for interacting with the S3 bucket
                 access_key: "<YOUR ACCESS KEY>",
                 secret_key: "<YOUR SECRET KEY>",
               },
@@ -166,6 +169,18 @@ storage_manager {
   ...
 }
 ```
+
+##### Note on credentials when working with AWS S3 storage
+
+The `private { access_key, secret_key }` block in the storage configuration is **optional**. When it is absent, the backend delegates credential resolution to the [AWS default credential provider chain](https://docs.rs/aws-config/latest/aws_config/default_provider/credentials/struct.DefaultCredentialsChain.html), which is tried in the following order:
+
+1. **Environment variables**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN` and `AWS_ACCOUNT_ID`
+2. **AWS profile file**: `~/.aws/config` and `~/.aws/credentials`
+3. **Web Identity Token**: `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` (optionally `AWS_ROLE_SESSION_NAME`)
+4. **ECS task IAM role**: checked when `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI` is set; ECS/Fargate injects these automatically when a task IAM role is attached
+5. **EC2 instance metadata (IMDSv2)**: queried last; provides the IAM role attached to the EC2 instance
+
+Omitting the credentials block is the recommended approach when running on AWS infrastructure (ECS, Fargate, EC2), as it avoids storing long-lived static credentials and relies instead on ephemeral IAM role credentials that rotate automatically.
 
 #### Volume configuration when working with MinIO
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,14 +58,17 @@ impl S3Client {
     ///   to retrieve the endpoint based on the specified region.
     /// * `tls_config`: optional TlsClientConfig to enable TLS security.
     pub async fn new(
-        credentials: Credentials,
+        credentials: Option<Credentials>,
         bucket: String,
         region: Option<String>,
         endpoint: Option<String>,
         tls_config: Option<TlsClientConfig>,
     ) -> Self {
-        let mut config_loader =
-            aws_config::ConfigLoader::default().credentials_provider(credentials);
+        let mut config_loader = aws_config::ConfigLoader::default();
+
+        if let Some(creds) = credentials {
+            config_loader = config_loader.credentials_provider(creds);
+        }
 
         config_loader = match region {
             Some(ref region) => config_loader.region(Region::new(region.to_owned())),

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,9 +72,9 @@ pub enum OnClosure {
 ///
 /// The fields of the struct have the following purposes:
 ///
-/// * credentials: is loaded from the access_key_id and secret_key_id set in the config file which
-///   were previously set in the S3 configuration in order to grant permissions to a user to
-///   perform operations such as read, write, create bucket, delete bucket...
+/// * credentials (optional): loaded from the access_key and secret_key set in the config file. When both
+///   fields are absent the AWS default credential provider chain is used instead (environment
+///   variables, ~/.aws/credentials, ECS task IAM role, EC2 instance metadata, etc.).
 /// * bucket: name of the bucket the storage is associated to
 /// * path_prefix: the path prefix stated under the `strip_prefix` value of the configuration file.
 ///   This prefix needs to match the key expression associated to this storage (otherwise Error
@@ -91,7 +91,7 @@ pub enum OnClosure {
 ///   was already created and is owned by you then the storage is associated to that preexisting
 ///   bucket.
 pub(crate) struct S3Config {
-    pub credentials: Credentials,
+    pub credentials: Option<Credentials>,
     pub bucket: String,
     pub path_prefix: Option<String>,
     pub key_expr: OwnedKeyExpr,
@@ -124,26 +124,35 @@ impl S3Config {
         })
     }
 
-    fn load_credentials(config: &StorageConfig) -> ZResult<Credentials> {
+    fn load_credentials(config: &StorageConfig) -> ZResult<Option<Credentials>> {
         let cfg: Value = (&config.volume_cfg).into();
         let volume_cfg = cfg.as_object().ok_or_else(|| {
             zerror!("Couldn't retrieve private properties of the storage from json5 config file.")
         })?;
 
         let access_key = get_private_conf(volume_cfg, PROP_S3_ACCESS_KEY)
-            .map_err(|err| zerror!("Could not load '{}': {}", PROP_S3_ACCESS_KEY, err))?
-            .ok_or_else(|| zerror!("Property '{PROP_S3_ACCESS_KEY}' needs to be of specified!"))?;
+            .map_err(|err| zerror!("Could not load '{}': {}", PROP_S3_ACCESS_KEY, err))?;
 
-        let secret_key = get_private_conf(volume_cfg, PROP_S3_SECRET_KEY)?
-            .ok_or_else(|| zerror!("Property '{PROP_S3_SECRET_KEY}' needs to be of specified!"))?;
+        let secret_key = get_private_conf(volume_cfg, PROP_S3_SECRET_KEY)?;
 
-        Ok(Credentials::new(
-            access_key,
-            secret_key,
-            None,
-            None,
-            DEFAULT_PROVIDER,
-        ))
+        match (access_key, secret_key) {
+            (None, None) => Ok(None),
+            (Some(access_key), Some(secret_key)) => Ok(Some(Credentials::new(
+                access_key,
+                secret_key,
+                None,
+                None,
+                DEFAULT_PROVIDER,
+            ))),
+            (Some(_), None) => Err(zerror!(
+                "Property '{PROP_S3_SECRET_KEY}' must be specified when '{PROP_S3_ACCESS_KEY}' is set"
+            )
+            .into()),
+            (None, Some(_)) => Err(zerror!(
+                "Property '{PROP_S3_ACCESS_KEY}' must be specified when '{PROP_S3_SECRET_KEY}' is set"
+            )
+            .into()),
+        }
     }
 
     fn load_bucket_name(config: &StorageConfig) -> ZResult<String> {


### PR DESCRIPTION
The AWS SDK implements by default a credential provider chain:
https://docs.rs/aws-config/latest/aws_config/default_provider/credentials/struct.DefaultCredentialsChain.html

This PR makes the storage credentials optional (mainly for MinIO usage). The default credential provider chain is used when credentials are not set in the configuration.
