### PR TITLE
Check bucket existance with HeadBucket rather to force its creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ If successful, then the console can be accessed on [http://localhost:9090](http:
               // Bucket to which this storage is associated to
               bucket: "zenoh-bucket",
 
-              // The storage attempts to create the bucket, but if the bucket already exists and is
-              // owned by you, then with 'reuse_bucket' you can associate that preexisting bucket to
-              // the storage, otherwise it will fail.
+              // The storage first checks whether the bucket exists using a read-only 'HeadBucket' call.
+              // If the bucket already exists and is accessible, then with 'reuse_bucket' set to true
+              // the storage is associated to that preexisting bucket; otherwise (bucket missing) it is created.
+              // When 'reuse_bucket' is false, an existing bucket makes the storage creation fail.
               reuse_bucket: true,
 
               // If the storage is read only, it will only handle GET requests

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,7 +20,7 @@ use aws_sdk_s3::{
     operation::{
         create_bucket::CreateBucketOutput, delete_object::DeleteObjectOutput,
         delete_objects::DeleteObjectsOutput, get_object::GetObjectOutput,
-        head_object::HeadObjectOutput, put_object::PutObjectOutput,
+        head_bucket::HeadBucketError, head_object::HeadObjectOutput, put_object::PutObjectOutput,
     },
     primitives::ByteStream,
     types::{
@@ -189,14 +189,50 @@ impl S3Client {
             .await?)
     }
 
-    /// Asyncronically creates the bucket associated to this client upon construction on a new
-    /// tokio runtime.
+    /// Ensures the bucket associated to this client is available.
+    ///
+    /// The bucket existence is first checked with a read-only `HeadBucket` call (which only
+    /// requires the `s3:ListBucket` permission) so that the mutating `CreateBucket` operation is
+    /// only issued when the bucket is actually missing.
+    ///
     /// Returns:
-    /// - Ok(Some(CreateBucketOutput)) in case the bucket was successfully created
-    /// - Ok(Some(None)) in case the `reuse_bucket` parameter is true and the bucket already exists
-    ///   and is owned by you
-    /// - Error in any other case
+    /// - `Ok(Some(CreateBucketOutput))` when the bucket was created
+    /// - `Ok(None)` when the bucket already exists and `reuse_bucket` is true
+    /// - `Err` in any other case (bucket already exists while `reuse_bucket` is false, missing
+    ///   permissions, network error, ...)
     pub async fn create_bucket(&self, reuse_bucket: bool) -> ZResult<Option<CreateBucketOutput>> {
+        // Read-only existence check (only requires the s3:ListBucket permission).
+        match self.client.head_bucket().bucket(&self.bucket).send().await {
+            Ok(_) => {
+                // The bucket exists and is accessible.
+                if reuse_bucket {
+                    Ok(None)
+                } else {
+                    Err(zerror!(
+                        "Bucket '{self}' already exists and is accessible while 'reuse_bucket' \
+                         is set to false in the configuration."
+                    )
+                    .into())
+                }
+            }
+            Err(err) => match err.into_service_error() {
+                HeadBucketError::NotFound(_) => {
+                    if reuse_bucket {
+                        tracing::info!(
+                            "Bucket '{self}' not found despite 'reuse_bucket' being enabled; creating it..."
+                        );
+                    }
+                    self.do_create_bucket().await.map(Some)
+                }
+                err => {
+                    Err(zerror!("Couldn't check the existence of bucket '{self}': {err:?}.").into())
+                }
+            },
+        }
+    }
+
+    /// Creates the bucket associated to this client with the default configuration.
+    async fn do_create_bucket(&self) -> ZResult<CreateBucketOutput> {
         let constraint = self
             .region
             .as_ref()
@@ -204,34 +240,13 @@ impl S3Client {
         let cfg = CreateBucketConfiguration::builder()
             .set_location_constraint(constraint)
             .build();
-        let result = self
-            .client
+        self.client
             .create_bucket()
             .create_bucket_configuration(cfg)
             .bucket(self.bucket.to_owned())
             .send()
-            .await;
-
-        match result {
-                Ok(output) => Ok(Some(output)),
-                Err(err) => {
-                    match err.into_service_error() {
-                        aws_sdk_s3::operation::create_bucket::CreateBucketError::BucketAlreadyOwnedByYou(_) => {
-                            if reuse_bucket {
-                                Ok(None)
-                            } else {
-                                Err(zerror!(
-                                    "Attempted to create bucket but '{self}' but it already exists and is
-                                    already owned by you while 'reuse_bucket' is set to false in the configuration."
-                                ).into())
-                            }
-                        },
-                        err => Err(zerror!(
-                            "Couldn't create or associate bucket '{self}': {err:?}."
-                        ).into()),
-                    }
-                }
-            }
+            .await
+            .map_err(|err| zerror!("Couldn't create bucket '{self}': {err:?}.").into())
     }
 
     /// Deletes the bucket associated to this storage.

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,9 +87,10 @@ pub enum OnClosure {
 ///   `destroy_bucket` or `do_nothing`. When setting `destroy_bucket` then the config field
 ///   `adminspace.permissions.write` must be set to true for the operation to succeed.
 /// * admin_status: the json value of the [StorageConfig]
-/// * reuse_bucket_is_enabled: the storage attempts to create the bucket but if the bucket
-///   was already created and is owned by you then the storage is associated to that preexisting
-///   bucket.
+/// * reuse_bucket_is_enabled: the storage first checks the bucket existence with a read-only
+///   `HeadBucket` call. If the bucket already exists and is accessible then the storage is
+///   associated to that preexisting bucket; otherwise the bucket is created. When disabled, an
+///   existing bucket is treated as an error.
 pub(crate) struct S3Config {
     pub credentials: Option<Credentials>,
     pub bucket: String,


### PR DESCRIPTION
Without any regard to the `reuse_bucket` config, the bucket creation is attempted anyway.
This always requires `s3:CreateBucket` permission, even if the user intent to create the bucket upfront and to always set `reuse_bucket:true`.

This PR make the backend to always check the bucket existence with [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) operation before to create it only if not found.
If the bucket was created upfront and `reuse_bucket == true`, no `s3:CreateBucket` permission is required.